### PR TITLE
Fix: Resolve navigation issues in mobile drawer menu (#11)

### DIFF
--- a/client/src/components/Nav/DrawerNav/DrawerNav.js
+++ b/client/src/components/Nav/DrawerNav/DrawerNav.js
@@ -29,16 +29,18 @@ const DrawerNav = () => {
         <Box
         sx={{ width: 250 }}
           role="presentation"
-          onClick={toggleDrawer(anchor, false)}
-          onKeyDown={toggleDrawer(anchor, false)}
         >
         <List>
-            {['Home', 'Shop', 'Men', 'Women', 'Kids'].map((text) => (
+            {[
+              { text: 'Home', to: '/' },
+              { text: 'Shop', to: '/shop' },
+              { text: 'Men', to: '/category/men' },
+              { text: 'Women', to: '/category/women' },
+              { text: 'Kids', to: '/category/kids' }
+            ].map(({ text, to }) => (
               <ListItem key={text} disablePadding>
-                <ListItemButton>
-                  <ListItemText>
-                    <Link to="/category/men">{text}</Link>
-                  </ListItemText>
+                <ListItemButton component={Link} to={to} onClick={toggleDrawer(anchor, false)}>
+                  <ListItemText primary={text} />
                 </ListItemButton>
               </ListItem>
             ))}
@@ -59,22 +61,28 @@ const DrawerNav = () => {
         </Box>
       );
 
-    return ( 
-        <Fragment>
-            {['left'].map((anchor) => (
-                <Fragment >
-                {state.left? <MenuOpenIcon fontSize='large' /> : <MenuIcon fontSize='large' onClick={toggleDrawer(anchor, true)} />}
-                <Drawer
-                    anchor={anchor}
-                    open={state[anchor]}
-                    onClose={toggleDrawer(anchor, false)}
-                >
-                    {list(anchor)}
-                </Drawer>
-                </Fragment>
-            ))}
-        </Fragment>
-     );
+    return (
+  <Fragment>
+    {['left'].map((anchor) => (
+      <Fragment key={anchor}>
+        <Box sx={{ p: 1 }}>
+          {state[anchor] ? (
+            <MenuOpenIcon fontSize="large" onClick={toggleDrawer(anchor, false)} />
+          ) : (
+            <MenuIcon fontSize="large" onClick={toggleDrawer(anchor, true)} />
+          )}
+        </Box>
+        <Drawer
+          anchor={anchor}
+          open={state[anchor]}
+          onClose={toggleDrawer(anchor, false)}
+        >
+          {list(anchor)}
+        </Drawer>
+      </Fragment>
+    ))}
+  </Fragment>
+);
 }
  
 export default DrawerNav;


### PR DESCRIPTION
**Issue #11**:

---

### 🛠️ Pull Request: Fix - Mobile Drawer Navigation Links Not Working Properly (#11)

---

### ✅ Description:

This PR addresses **Issue #11**, where the **navigation links inside the mobile drawer menu were not working as expected**. Specifically:

* Only the **"Men"** button was functional.
* Other links like **Home, Shop, Women, Kids** were **not responding to clicks**.

---

### 🔍 Root Cause:

The `<Link>` component was incorrectly placed **inside** `<ListItemText>`, which led to improper rendering and navigation issues.

---

### ✅ Fix Implemented:

* Updated the `ListItemButton` to use the `Link` component **as its root** via `component={Link}`.
* Passed the `to` prop directly to `ListItemButton`.
* Ensured that clicking any menu item also **closes the drawer** using `onClick={toggleDrawer(anchor, false)}`.
* Ensured all nav routes now function correctly on mobile.

---

### 📦 Affected Files:

* `DrawerNav.jsx`

---

### 🧪 Tested:

* ✅ All drawer links now route correctly (`Home`, `Shop`, `Men`, `Women`, `Kids`).
* ✅ Drawer closes when a menu item is clicked.
* ✅ Toggle icon now fully functional for open/close behavior.

---

### 🔗 Related Issue:

Closes #11

---