### PR TITLE
removed issue of header overlapping the pages of the footer

### DIFF
--- a/client/src/Pages/Footer/Accessibility/Accessibility.css
+++ b/client/src/Pages/Footer/Accessibility/Accessibility.css
@@ -1,6 +1,6 @@
 .accessibility-container {
     max-width: 800px;
-    margin: 1rem auto;
+    margin: 0 auto;
     padding: 2rem 1rem;
     line-height: 1.6;
     font-size: 1rem;

--- a/client/src/Pages/Footer/Accessibility/Accessibility.js
+++ b/client/src/Pages/Footer/Accessibility/Accessibility.js
@@ -4,7 +4,7 @@ import EmailIcon from '@mui/icons-material/Email';
 
 const AccessiblityPage = () => {
     return (
-        <div className="accessibility-container">
+        <div className="accessibility-container" style={{ paddingTop: '160px' }}>
             <h1>Accessibility Statement</h1>
                 <p>
                     At TrendHora, we are committed to ensuring that our website is accessible to all users, regardless of ability.

--- a/client/src/Pages/Footer/Faq/FaqList.js
+++ b/client/src/Pages/Footer/Faq/FaqList.js
@@ -42,7 +42,7 @@ const FaqList = () => {
     ]
 
     return (
-        <div className="container">
+        <div className="container" style={{ paddingTop: '160px' }}>
             <div className="heading">
                 <h1>Frequently asked Questions</h1>
             </div>

--- a/client/src/Pages/Footer/Refund/Refund.js
+++ b/client/src/Pages/Footer/Refund/Refund.js
@@ -2,7 +2,7 @@ import "./Refund.css"
 
 const RefundPage = () => {
     return (
-        <div className="refund-container">
+        <div className="refund-container" style={{ paddingTop: '160px' }}>
             <h1>Check Refund Status</h1>
             <p>Enter your Order ID to check the status of your refund.</p>
             <form className="refund-form">

--- a/client/src/Pages/Footer/Shipping/Shipping.js
+++ b/client/src/Pages/Footer/Shipping/Shipping.js
@@ -2,7 +2,7 @@ import "./Shipping.css"
 
 const ShippingPage = () => {
     return (
-        <div className="container">
+        <div className="container" style={{ paddingTop: '160px' }}>
             <div className="heading">
                 <h1>Shipping Information</h1>
             </div>


### PR DESCRIPTION
## ✅ Checklist Before Submitting

- [x] I’ve tested the code locally and now header is not overlapping the footer pages 
- [x] I’ve added screenshots 
- [x] I’ve followed the code style and contribution guidelines

## 📝 Description

The PR fixes the issue of the footer pages (FAQ,Shipping,Accessibilty,Refund) those were previously being iverlapped by the header are now being fully visible and not overlapped .And nothing is overlapping and all the content of the pages are now visible.

## 📸 Screenshots 
<img width="1917" height="888" alt="image" src="https://github.com/user-attachments/assets/a909ee56-0d2c-4f90-89e9-8d4d3d32f326" />

