### PR TITLE
Fix: adjusted padding and styled Accessibility Statement page

### DIFF
--- a/client/src/Pages/Footer/Accessibility/Accessibility.css
+++ b/client/src/Pages/Footer/Accessibility/Accessibility.css
@@ -41,3 +41,31 @@ p {
   color: #464545;
   text-align: justify;
 }
+
+.accessibility-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 200px 1rem 2rem; 
+  line-height: 1.6;
+  font-size: 1rem;
+  color: #333;
+}
+
+
+.accessibility-container h1 {
+  position: relative;
+  margin-bottom: 30px;   
+  padding-bottom: 12px;
+  font-size: 2rem;
+  color: #222;
+}
+
+.accessibility-container h1::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 80px;              
+  height: 3px;
+  background-color: #FFD633; 
+}

--- a/client/src/Pages/Footer/Accessibility/Accessibility.js
+++ b/client/src/Pages/Footer/Accessibility/Accessibility.js
@@ -4,7 +4,7 @@ import EmailIcon from '@mui/icons-material/Email';
 
 const AccessiblityPage = () => {
     return (
-        <div className="accessibility-container" style={{ paddingTop: '160px' }}>
+        <div className="accessibility-container">
             <h1>Accessibility Statement</h1>
                 <p>
                     At TrendHora, we are committed to ensuring that our website is accessible to all users, regardless of ability.

--- a/client/src/components/Category/Category.js
+++ b/client/src/components/Category/Category.js
@@ -181,7 +181,34 @@ const Category = (props) => {
                     <div className="category__product__card">
                         {filteredAndSortedItems.map((data, index) => <ItemCard key={data._id || index} item={data} category={props.category}/>)}
                         <div className="show__more__action">
-                            <Button variant='outlined' sx={[ {width: '200px', height: '50px', borderRadius: '20px' , fontWeight: '700', backgroundColor: '#FFE26E', borderColor: '#FFE26E', color: 'black' }, {'&:hover': { borderColor: '#FFE26E', backgroundColor: "none" }}]}>Show more</Button>
+                            {/* <Button variant='outlined' sx={[ {width: '200px', height: '50px', borderRadius: '20px' , fontWeight: '700', backgroundColor: '#FFE26E', borderColor: '#FFE26E', color: 'black' }, {'&:hover': { borderColor: '#FFE26E', backgroundColor: "none" }}]}>Show more</Button> */}
+                            <Button
+                                variant="outlined"
+                                sx={{
+                                width: '200px',
+                                height: '50px',
+                                borderRadius: '20px',
+                                fontWeight: '700',
+                                backgroundColor: '#FFE26E',
+                                borderColor: '#FFE26E',
+                                color: 'black',
+                                '&:hover': {
+                                    backgroundColor: '#FFD633',
+                                    borderColor: '#FFD633',
+                                    },
+                                '&:active': {
+                                    backgroundColor: '#FFCC00',
+                                    borderColor: '#FFCC00',
+                                },
+                                '&:focus': {
+                                    backgroundColor: '#FFE26E',
+                                    borderColor: '#FFE26E',
+                                    outline: 'none',
+                                },
+                            }}
+                    >Show more
+                </Button>
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## ✅ Checklist Before Submitting

- [ yes] I’ve tested the code locally and it works as expected
- [ yes] I’ve added screenshots if applicable
- [ yes] I’ve followed the code style and contribution guidelines

## 📝 Description
This PR includes the following fixes:
  -Accessibility Statement Page
         Adjusted top padding so the h1 heading and underline are fully visible below the navbar.
         Improved heading underline style (brand color, spacing).
  -"Show More" Button
         Fixed hover and active state styles — button now stays yellow with black text instead of turning dark after click.
        Added smooth hover effect with darker yellow background.
_What does this PR do? Brief summary here._
    This PR fixes UI issues in the Accessibility Statement page and the “Show More” button. Specifically:
    Adjusts padding on the Accessibility page so the heading and underline are fully visible below the navbar.
    Styles the heading underline with the brand yellow color for consistency.
    Fixes the “Show More” button hover/active states so it stays yellow with black text instead of turning dark.
## 📸 Screenshots (if applicable)

_Paste screenshots here to show your tested feature_
Accessibility Page – Before: 
<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/a2affb57-9889-45f7-a075-5e618b41e44e" />
Accessibility Page – After:
<img width="1919" height="1028" alt="Screenshot 2025-08-26 185539" src="https://github.com/user-attachments/assets/eed44996-27f3-4e03-aaac-d042b0d90ce4" />
Show More Button – Before:
<img width="1910" height="1025" alt="image" src="https://github.com/user-attachments/assets/815914bd-5b1d-4383-a7cc-c448e6bd392c" />

Show More Button – After:
<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/ca4f7ad9-ff8c-4812-8a50-0e30f1a3357c" />
