### PR TITLE
Fixed shipping, accessibility and faq page text visbility in dark mode

### DIFF
--- a/client/src/Pages/Footer/Accessibility/Accessibility.css
+++ b/client/src/Pages/Footer/Accessibility/Accessibility.css
@@ -1,30 +1,30 @@
-
 .accessibility-container h1:first-child {
-    margin-top: 4rem; 
+  margin-top: 4rem;
 }
+
 .accessibility-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-    line-height: 1.6;
-    font-size: 1rem;
-    color: #333;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  line-height: 1.6;
+  font-size: 1rem;
+  color: #333;
 }
 
-.list{
-    list-style-type: disc;
-    padding-left: 2rem;
-    margin-top: 1rem;
-    line-height: 1.6;
-    color: #464545;
+.list {
+  list-style-type: disc;
+  padding-left: 2rem;
+  margin-top: 1rem;
+  line-height: 1.6;
+  color: #464545;
 }
 
-.list-item{
-    margin-bottom: 0.5rem;
+.list-item {
+  margin-bottom: 0.5rem;
 }
 
-.heading{
-    margin-bottom: 1rem;
+.heading {
+  margin-bottom: 1rem;
 }
 
 h1 {
@@ -49,7 +49,7 @@ p {
 .accessibility-container {
   max-width: 800px;
   margin: 0 auto;
-  padding: 200px 1rem 2rem; 
+  padding: 200px 1rem 2rem;
   line-height: 1.6;
   font-size: 1rem;
   color: #333;
@@ -58,7 +58,7 @@ p {
 
 .accessibility-container h1 {
   position: relative;
-  margin-bottom: 30px;   
+  margin-bottom: 30px;
   padding-bottom: 12px;
   font-size: 2rem;
   color: #222;
@@ -69,7 +69,41 @@ p {
   position: absolute;
   left: 0;
   bottom: 0;
-  width: 80px;              
+  width: 80px;
   height: 3px;
-  background-color: #FFD633; 
+  background-color: #FFD633;
+}
+
+/* Dark mode default text colors */
+
+.dark-mode .accessibility-container {
+  color: #e0e0e0;
+}
+
+.dark-mode .accessibility-container h1 {
+  color: #e0e0e0;
+}
+
+.dark-mode .accessibility-container h2 {
+  color: #e0e0e0;
+}
+
+.dark-mode .accessibility-container p {
+  color: var(--text-secondary);
+}
+
+.dark-mode .list {
+  color: var(--text-secondary);
+}
+
+.dark-mode .accessibility-container a {
+  color: var(--text-secondary);
+}
+
+.dark-mode .accessibility-container a:hover {
+  color: var(--text-secondary);
+}
+
+.dark-mode .accessibility-container .MuiSvgIcon-root {
+  color: var(--text-secondary);
 }

--- a/client/src/Pages/Footer/Faq/Faq.css
+++ b/client/src/Pages/Footer/Faq/Faq.css
@@ -1,13 +1,19 @@
-.container{
-    margin:4rem auto;
+.container {
+    margin: 4rem auto;
 }
-.heading{
+
+.heading {
     padding: 1rem;
     text-align: center;
     font-family: "Playfair Display";
+    color: #333;
 }
 
-.faq-container{
+.heading h1 {
+    color: #333;
+}
+
+.faq-container {
     margin-top: 2rem;
     margin-left: auto;
     margin-right: auto;
@@ -16,19 +22,25 @@
     border: 1px solid gray;
     padding: 1.5rem;
     border-radius: 0.5rem;
-    box-shadow:0px 0px 1rem rgb(183, 181, 181);
+    box-shadow: 0px 0px 1rem rgb(183, 181, 181);
     width: 70%;
-}
-.question{
-    display: flex;
-    justify-content: space-between;   
-}
-.faq-toggle-button{
-    font-size: 20px;
-    margin-left: 2rem;
+    background-color: #ffffff;
+    color: #333;
 }
 
-.answer{
+.question {
+    display: flex;
+    justify-content: space-between;
+    color: #333;
+}
+
+.faq-toggle-button {
+    font-size: 20px;
+    margin-left: 2rem;
+    color: #333;
+}
+
+.answer {
     background-color: rgb(239, 246, 247);
     margin-bottom: 1rem;
     margin-left: auto;
@@ -38,29 +50,35 @@
     padding: 1.5rem;
     border-bottom-left-radius: 0.5rem;
     border-bottom-right-radius: 0.5rem;
-    box-shadow:0px 0px 1.5rem rgb(183, 181, 181);
+    box-shadow: 0px 0px 1.5rem rgb(183, 181, 181);
     width: 70%;
+    color: #333;
 }
+
 @media (prefers-color-scheme: dark) {
     .heading {
         color: #e0e0e0;
     }
-    
+
+    .dark-mode .heading h1 {
+        color: #e0e0e0;
+    }
+
     .faq-container {
         background-color: #2a2a2a;
         color: #e0e0e0;
         border-color: #555;
         box-shadow: 0px 0px 1rem rgba(0, 0, 0, 0.5);
     }
-    
+
     .question {
         color: #e0e0e0;
     }
-    
+
     .faq-toggle-button {
         color: #e0e0e0;
     }
-    
+
     .answer {
         background-color: #3a3a3a;
         color: #e0e0e0;

--- a/client/src/Pages/Footer/Shipping/Shipping.css
+++ b/client/src/Pages/Footer/Shipping/Shipping.css
@@ -1,13 +1,14 @@
-.container{
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-    line-height: 1.6;
-    font-size: 1rem;
-    color: #333;
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  line-height: 1.6;
+  font-size: 1rem;
+  color: #333;
 }
-.heading{
-    margin-bottom: 1rem;
+
+.heading {
+  margin-bottom: 1rem;
 }
 
 h1 {
@@ -27,4 +28,20 @@ p {
   font-size: 1rem;
   color: #464545;
   text-align: justify;
+}
+
+.dark-mode .container {
+  color: #e0e0e0;
+}
+
+.dark-mode .container .heading h1 {
+  color: #e0e0e0;
+}
+
+.dark-mode .container h2 {
+  color: var(--text-primary);
+}
+
+.dark-mode .container p {
+  color: var(--text-secondary);
 }


### PR DESCRIPTION
Fixes : #298 

## 📝 Description

This PR fixes **text visibility issues** on the **Shipping**, **Accessibility**, and **FAQ** pages in dark mode.  

- Adjusted font colors to maintain proper contrast with the background.  
- Ensured text content is clearly visible in both **light** and **dark** modes.  
- Improved overall **readability** and **accessibility** across these pages.  

### Fixes #

- Text blending with the background in dark mode on the following routes:
  - `/shipping`
  - `/faq`
  - `/accessibility`



## ✅ Checklist Before Submitting

- [x] I’ve tested the code locally and it works as expected
- [x] I’ve added screenshots if applicable
- [x] I’ve followed the code style and contribution guidelines

## 📸 Screenshots (if applicable)

<img width="1822" height="775" alt="image" src="https://github.com/user-attachments/assets/b3c6ef70-a3db-40d1-a814-a8ba533e808b" />


<img width="1822" height="775" alt="image" src="https://github.com/user-attachments/assets/4dafa2f5-7e64-4c64-b9c4-d62f83d4a1a2" />


<img width="1822" height="775" alt="image" src="https://github.com/user-attachments/assets/b89524e8-1b33-4785-8d09-2919db023751" />


