### PR TITLE
Fixed inconsistent page background and text color of static pages 

### DIFF
--- a/client/src/components/Legal/PrivacyPolicy/PrivacyPolicy.css
+++ b/client/src/components/Legal/PrivacyPolicy/PrivacyPolicy.css
@@ -1,9 +1,11 @@
 /* Privacy Policy Page Styles */
 
-.privacy-container {
+.privacy-policy-container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
+    background: var(--card-bg);
+    color: var(--text-color);
 }
 
 .back-button {
@@ -12,7 +14,7 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    color: #333;
+    color: var(--text-color);
     font-size: 16px;
     margin-bottom: 20px;
     transition: color 0.3s ease;
@@ -23,62 +25,74 @@
 }
 
 .privacy-paper {
-    background: #fff;
+    background: var(--card-bg) !important;
+    color: var(--text-color) !important;
+    padding: 40px;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 .privacy-title {
-    color: #1976d2;
+    color: var(--text-color) !important;
     font-weight: 600;
     margin-bottom: 20px;
 }
 
 .privacy-date {
-    color: #666;
+    color: var(--text-color);
     font-size: 14px;
     margin-bottom: 20px;
 }
 
+.section-container {
+    display: flex;
+    flex-direction: column;
+    align-items: self-start;
+    text-align: start;
+}
+
 .section-title {
-    color: #333;
+    color: var(--text-color);
     font-weight: 600;
     margin-bottom: 15px;
     margin-top: 30px;
 }
 
 .section-content {
-    color: #555;
+    color: var(--text-color);
     line-height: 1.6;
     margin-bottom: 20px;
+    text-align: start;
 }
 
 .privacy-list {
     padding-left: 20px;
     margin-bottom: 20px;
+    color: var(--text-color);
 }
 
 .privacy-list li {
     margin-bottom: 8px;
-    color: #555;
+    color: var(--text-color);
 }
 
 .contact-details {
     padding-left: 20px;
     margin-bottom: 20px;
+    background-color: var(--card-bg);
+    border: 1px solid #e0e0e0;
+    width: 100%;
 }
 
 .contact-details p {
     margin-bottom: 8px;
-    color: #555;
+    color: var(--text-color);
 }
 
-.effective-date {
-    text-align: center;
-    color: #666;
-    margin-top: 30px;
-    padding-top: 20px;
-    border-top: 1px solid #eee;
+.disclaimer {
+    color: var(--text-color);
+    background-color: var(--card-bg);
+    border: 1px solid #e0e0e0;
 }
 
 /* Responsive Design */
@@ -86,15 +100,15 @@
     .privacy-container {
         padding: 10px;
     }
-    
+
     .privacy-paper {
         padding: 20px;
     }
-    
+
     .privacy-title {
         font-size: 24px;
     }
-    
+
     .section-title {
         font-size: 18px;
     }
@@ -104,12 +118,12 @@
     .privacy-paper {
         padding: 15px;
     }
-    
+
     .privacy-title {
         font-size: 20px;
     }
-    
+
     .section-title {
         font-size: 16px;
     }
-} 
+}

--- a/client/src/components/Legal/PrivacyPolicy/PrivacyPolicy.js
+++ b/client/src/components/Legal/PrivacyPolicy/PrivacyPolicy.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import './PrivacyPolicy.css';
 import { Container, Typography, Box, Paper, Divider } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -23,31 +23,27 @@ const PrivacyPolicy = () => {
     };
 
     return (
-        <Box sx={{ 
+        <Box 
+        className="privacy-policy-container"    
+        sx={{ 
             pt: { xs: '120px', sm: '140px', md: '160px' }, 
             pb: 4,
-            minHeight: '100vh',
-            backgroundColor: '#f8f9fa'
+            minHeight: '100vh'
         }}>
             <Container maxWidth="lg" sx={{ py: 4 }}>
                 <Box sx={{ mb: 3 }}>
                     <button 
                         onClick={handleBack}
+                        className='back-button'
                         style={{
-                            background: 'none',
-                            border: 'none',
                             display: 'flex',
                             alignItems: 'center',
                             cursor: 'pointer',
-                            color: '#333',
                             fontSize: '16px',
                             marginBottom: '20px',
                             padding: '8px 12px',
                             borderRadius: '6px',
                             transition: 'all 0.3s ease',
-                            ':hover': {
-                                backgroundColor: '#f0f0f0'
-                            }
                         }}
                     >
                         <ArrowBackIcon sx={{ mr: 1 }} />
@@ -55,14 +51,10 @@ const PrivacyPolicy = () => {
                     </button>
                 </Box>
 
-                <Paper elevation={3} sx={{ 
+                <Paper elevation={3} className='privacy-paper' sx={{ 
                     p: { xs: 3, md: 4 },
-                    borderRadius: '12px',
-                    backgroundColor: '#ffffff',
-                    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)'
                 }}>
-                    <Typography variant="h3" component="h1" gutterBottom sx={{ 
-                        color: '#1a1a1a', 
+                    <Typography variant="h3" component="h1" gutterBottom className='privacy-title' sx={{ 
                         mb: 3,
                         fontWeight: 700,
                         fontSize: { xs: '28px', md: '32px' }
@@ -70,27 +62,25 @@ const PrivacyPolicy = () => {
                         Privacy Policy
                     </Typography>
                     
-                    <Typography variant="body2" sx={{ mb: 2, color: '#666', fontStyle: 'italic' }}>
+                    <Typography variant="body2" className='privacy-date' sx={{ mb: 2, fontStyle: 'italic' }}>
                         Last updated: January 2025
                     </Typography>
 
                     <Divider sx={{ mb: 3, borderColor: '#e0e0e0' }} />
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{ 
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             1. Information We Collect
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We collect information you provide directly to us, such as when you create an account, make a purchase, or contact us for support. This may include:
                         </Typography>
-                        <ul style={{ 
+                        <ul className="privacy-list" style={{ 
                             paddingLeft: '20px',
-                            color: '#555',
                             lineHeight: 1.7
                         }}>
                             <li>Name, email address, and phone number</li>
@@ -101,21 +91,19 @@ const PrivacyPolicy = () => {
                         </ul>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{  
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             2. How We Use Your Information
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We use the information we collect to:
                         </Typography>
-                        <ul style={{ 
+                        <ul className="privacy-list" style={{ 
                             paddingLeft: '20px',
-                            color: '#555',
                             lineHeight: 1.7
                         }}>
                             <li>Process and fulfill your orders</li>
@@ -127,21 +115,19 @@ const PrivacyPolicy = () => {
                         </ul>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{  
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             3. Information Sharing
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We do not sell, trade, or otherwise transfer your personal information to third parties except in the following circumstances:
                         </Typography>
-                        <ul style={{ 
+                        <ul className="privacy-list" style={{ 
                             paddingLeft: '20px',
-                            color: '#555',
                             lineHeight: 1.7
                         }}>
                             <li>With your explicit consent</li>
@@ -151,49 +137,45 @@ const PrivacyPolicy = () => {
                         </ul>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{ 
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             4. Cookies and Tracking Technologies
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We use cookies and similar tracking technologies to enhance your browsing experience, analyze website traffic, and understand where our visitors are coming from. You can control cookie settings through your browser preferences.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{ 
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             5. Data Security
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We implement appropriate security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the internet is 100% secure.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{ 
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             6. Your Rights
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             You have the right to:
                         </Typography>
-                        <ul style={{ 
+                        <ul className='privacy-list' style={{ 
                             paddingLeft: '20px',
-                            color: '#555',
                             lineHeight: 1.7
                         }}>
                             <li>Access your personal information</li>
@@ -204,74 +186,68 @@ const PrivacyPolicy = () => {
                         </ul>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{ 
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             7. Children's Privacy
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             Our website is not intended for children under 13 years of age. We do not knowingly collect personal information from children under 13. If you are a parent and believe your child has provided us with personal information, please contact us.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             8. International Transfers
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             Your information may be transferred to and processed in countries other than your own. We ensure that such transfers comply with applicable data protection laws.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             9. Changes to This Policy
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="h5" gutterBottom sx={{ 
-                            color: '#1a1a1a', 
+                    <Box sx={{ mb: 4 }} className='section-container'>
+                        <Typography variant="h5" gutterBottom className='section-title' sx={{
                             mb: 2,
                             fontWeight: 600,
                             fontSize: { xs: '18px', md: '20px' }
                         }}>
                             10. Contact Us
                         </Typography>
-                        <Typography variant="body1" paragraph sx={{ color: '#555', lineHeight: 1.7 }}>
+                        <Typography variant="body1" paragraph className='section-content' sx={{ lineHeight: 1.7 }}>
                             If you have any questions about this Privacy Policy or our data practices, please contact us at:
                         </Typography>
-                        <Box sx={{ 
+                        <Box className='contact-details' sx={{ 
                             pl: 2,
-                            backgroundColor: '#f8f9fa',
                             padding: '16px',
-                            borderRadius: '8px',
-                            border: '1px solid #e0e0e0'
+                            borderRadius: '8px'
                         }}>
-                            <Typography variant="body1" sx={{ color: '#555', mb: 1 }}>
+                            <Typography variant="body1" sx={{ mb: 1 }}>
                                 Email: shop@trendhora.com
                             </Typography>
-                            <Typography variant="body1" sx={{ color: '#555', mb: 1 }}>
+                            <Typography variant="body1" sx={{ mb: 1 }}>
                                 Phone: +91 9319042075
                             </Typography>
-                            <Typography variant="body1" sx={{ color: '#555' }}>
+                            <Typography variant="body1" >
                                 Address: Delhi, India
                             </Typography>
                         </Box>
@@ -279,14 +255,11 @@ const PrivacyPolicy = () => {
 
                     <Divider sx={{ my: 3, borderColor: '#e0e0e0' }} />
 
-                    <Typography variant="body2" sx={{ 
-                        color: '#666', 
+                    <Typography variant="body2" className='disclaimer' sx={{  
                         textAlign: 'center',
                         fontStyle: 'italic',
-                        backgroundColor: '#f8f9fa',
                         padding: '16px',
                         borderRadius: '8px',
-                        border: '1px solid #e0e0e0'
                     }}>
                         This Privacy Policy is effective as of January 2025 and will remain in effect except with respect to any changes in its provisions in the future.
                     </Typography>

--- a/client/src/components/Legal/TermsConditions/TermsConditions.css
+++ b/client/src/components/Legal/TermsConditions/TermsConditions.css
@@ -9,12 +9,10 @@
 }
 
 .terms-page-wrapper {
-  background-color: var(--trendhora-dark);
+  background-color: var(--card-bg);
   min-height: 100vh;
   padding: 60px 20px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  /* Ensuring all text in wrapper is white */
-  color: #ffffff;
 }
 
 .terms-container {
@@ -31,7 +29,7 @@
   align-items: center;
   gap: 10px;
   /* Making back button visible by default with yellow background */
-  background: var(--trendhora-yellow);
+  background: var(--card-bg);
   border: 2px solid var(--trendhora-yellow);
   color: var(--trendhora-dark);
   padding: 14px 28px;
@@ -58,7 +56,7 @@
 
 /* Enhanced header card with better visual impact */
 .terms-header-card {
-  background: linear-gradient(135deg, var(--trendhora-card-bg) 0%, var(--trendhora-dark) 100%);
+  background: linear-gradient(135deg, var(--card-bg) 0%, var(--card-bg) 100%);
   border: 2px solid var(--trendhora-yellow);
   border-radius: 16px;
   padding: 50px 40px;
@@ -68,7 +66,7 @@
 }
 
 .terms-title {
-  color: #ffffff;
+  color: var(--text-color);
   font-size: 3rem;
   font-weight: 800;
   margin-bottom: 20px;
@@ -90,7 +88,7 @@
 }
 
 .terms-card {
-  background: linear-gradient(135deg, var(--trendhora-card-bg) 0%, var(--trendhora-dark) 100%);
+  background: linear-gradient(135deg, var(--card-bg) 0%, var(--card-bg) 100%);
   border: 2px solid var(--trendhora-yellow);
   border-radius: 16px;
   padding: 35px;
@@ -105,7 +103,7 @@
 }
 
 .section-title {
-  color: var(--trendhora-yellow);
+  color: var(--text-color);
   font-size: 1.6rem;
   font-weight: 700;
   margin-bottom: 25px;
@@ -128,7 +126,7 @@
 }
 
 .section-content {
-  color: #ffffff !important;
+  color: var(--text-color) !important;
   font-size: 1.1rem;
   line-height: 1.8;
   margin-bottom: 20px;
@@ -142,7 +140,7 @@
 }
 
 .terms-list li {
-  color: #ffffff !important;
+  color: var(--text-primary) !important;
   font-size: 1.05rem;
   line-height: 1.7;
   margin-bottom: 15px;
@@ -158,7 +156,7 @@
 
 /* Enhanced contact card with better visual appeal */
 .contact-card {
-  background: linear-gradient(135deg, var(--trendhora-card-bg) 0%, var(--trendhora-dark) 100%);
+  background: linear-gradient(135deg, var(--card-bg) 0%, var(--card-bg) 100%);
   border: 2px solid var(--trendhora-yellow);
   border-radius: 16px;
   padding: 40px;
@@ -167,7 +165,7 @@
 }
 
 .contact-info {
-  color: #ffffff !important;
+  color: var(--text-color);
   font-size: 1.2rem;
   line-height: 1.8;
   margin: 0;
@@ -187,7 +185,6 @@
 }
 
 .contact-link:hover {
-  background-color: var(--trendhora-yellow);
   color: var(--trendhora-dark);
   border-color: var(--trendhora-yellow);
   transform: translateY(-2px);
@@ -196,7 +193,7 @@
 
 /* Adding universal text color override to ensure all text is white */
 .terms-page-wrapper * {
-  color: #ffffff;
+  color: var(--text-color);
 }
 
 .terms-page-wrapper .section-title,


### PR DESCRIPTION
Fixes : #300 

## 📝 Description

This PR fixes the **theme inconsistency issue** on static pages, ensuring proper light and dark mode support across all routes.  

- Fixed background and text color issues on:
  - **Privacy Policy Page** → Previously appeared white in both modes.  
  - **Terms & Conditions Page** → Previously appeared black in both modes.  
- Ensured all pages now **adapt correctly** to light and dark modes.  
- Maintained proper **color contrast** for improved readability and accessibility.  
- Enhanced overall **UI consistency** and **user experience** across themes.  

### Fixes #

- Static pages not following the selected light/dark mode theme:
  - `/privacy`
  - `/terms`


## ✅ Checklist Before Submitting

- [x] I’ve tested the code locally and it works as expected
- [x] I’ve added screenshots if applicable
- [x] I’ve followed the code style and contribution guidelines

## 📸 Screens (Before & After)

### 🎥 Before
<img width="1843" height="848" alt="image" src="https://github.com/user-attachments/assets/2e10c733-9c2e-418c-956a-04c51ef8480b" />

<img width="1843" height="848" alt="image" src="https://github.com/user-attachments/assets/f0ec0b78-d976-482f-902d-3a5742d5cdcf" />



### 🎥 After

<img width="1843" height="848" alt="image" src="https://github.com/user-attachments/assets/02b552ad-a785-4620-84f2-7b878c9805fc" />

<img width="1843" height="848" alt="image" src="https://github.com/user-attachments/assets/72c53a8e-52b5-410d-a853-3d376335e3fe" />

