### PR TITLE
Fix: made entire product card clickable using Link

### DIFF
--- a/client/src/components/Card/ItemCard/ItemCard.js
+++ b/client/src/components/Card/ItemCard/ItemCard.js
@@ -214,13 +214,26 @@ const ItemCard = (props) => {
   const detailPath = itemCategory && itemId ? `/item/${itemCategory}/${itemId}` : "#";
 
   return (
-    <div
+    <Link
+     to={detailPath}
+  onClick={(e) => {
+    if (detailPath === "#") {
+      e.preventDefault();
+      setToasterTitle("Error");
+      setToasterMessage("Could not open product details. Please try again.");
+      setToasterType("error");
+      setShowToaster(true);
+      return;
+    }
+    saveToRecentlyViewed(currentItem);
+  }}
+    
       className={`product__card__card ${isHovered ? "hovered" : ""}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       style={{ cursor: "pointer" }}
     >
-      <div className="product__image" onClick={handleProductClick}>
+      <div className="product__image">
         <img
           src={isHovered && hoverImageUrl ? hoverImageUrl : imageUrl}
           alt={currentItem.name || "Product"}
@@ -257,22 +270,7 @@ const ItemCard = (props) => {
       <div className="product__card__detail">
         <span className="category-badge">{itemCategory}</span>
         <div className="product__name">
-          <Link
-            to={detailPath}
-            onClick={(e) => {
-              if (detailPath === "#") {
-                e.preventDefault();
-                setToasterTitle("Error");
-                setToasterMessage("Could not open product details. Please try again.");
-                setToasterType("error");
-                setShowToaster(true);
-                return;
-              }
-              saveToRecentlyViewed(currentItem);
-            }}
-          >
-            {currentItem.name}
-          </Link>
+          {currentItem.name || "Unnamed Product"}
         </div>
         <div className="product__price">${currentItem.price}</div>
         <div className="product__card__action">
@@ -313,7 +311,7 @@ const ItemCard = (props) => {
         type={toasterType}
         duration={1000}
       />
-    </div>
+    </Link>
   );
 };
 


### PR DESCRIPTION
💡 Description

This PR fixes **Issue #28** by making the entire product card clickable instead of just the product title.
The change improves user experience by allowing users to click anywhere on the product card to navigate to the product detail page.

🛠 Changes Made

* Wrapped the entire product card component inside a `<Link>` element.
* Ensured the `Link` navigates to the corresponding product detail route.
* Verified that hover and focus states are preserved for accessibility.


🧩 Fixes

Fixes #28
