### PR TITLE
Horizontally centred text in all contact cards

### DIFF
--- a/client/src/routes/ContactUs.css
+++ b/client/src/routes/ContactUs.css
@@ -437,6 +437,7 @@
   .contact__card p {
     color: #f1f1f1;
     margin-bottom: 0.4rem;
+    text-align: center;
   }
 
   .contact__card__subtitle {


### PR DESCRIPTION
## 📝 Description

Successfully aligns text in EmailUs,CallUs,VisitUs contact cards 

### Fixes #380 
<!-- Add the issue assigned for the chnages made in PR -->



## ✅ Checklist Before Submitting

- [ ] I’ve tested the code locally and it works as expected
- [ ] I’ve added screenshots if applicable
- [ ] I’ve followed the code style and contribution guidelines

## 📸 Screenshots (if applicable)
<img width="1150" height="393" alt="image" src="https://github.com/user-attachments/assets/2cc5fecd-4c78-4747-99d4-b8b3b5d939db" />


_Paste screenshots here to show your tested feature_
