### PR TITLE
fix: chatbot reply alignment

### DIFF
--- a/client/src/components/Chatbot/Chatbot.css
+++ b/client/src/components/Chatbot/Chatbot.css
@@ -261,6 +261,7 @@
   padding: 12px 16px;
   line-height: 1.4;
   word-wrap: break-word;
+  text-align: left;
 }
 
 .message-text a {


### PR DESCRIPTION
## 📝 Description
The replies from chatbot were previously center aligned making long texts look unprofessional. Fixed it to be left-aligned - just how it should be.

### Fixes 
#382 

## ✅ Checklist Before Submitting

- [x] I’ve tested the code locally and it works as expected
- [x] I’ve added screenshots if applicable
- [x] I’ve followed the code style and contribution guidelines

## 📸 Screenshots 
Before:
<img width="581" height="731" alt="Screenshot 2025-10-18 184330" src="https://github.com/user-attachments/assets/bf8c59cb-5a33-4367-9efb-7da3f7141e01" />
After:
<img width="572" height="826" alt="image" src="https://github.com/user-attachments/assets/6c325db4-e717-4ffd-9758-44aaabf1ceb2" />

