### PR TITLE
fix:about us page tagline center aligned

### DIFF
--- a/client/src/routes/About.css
+++ b/client/src/routes/About.css
@@ -53,6 +53,7 @@
   margin-bottom: 0;
   font-weight: 400;
   line-height: 1.6;
+  text-align: center;
 }
 
 /* Section Styles */


### PR DESCRIPTION
## 📝 Description

Center aligned the about us page tagline

### Fixes 
#384 



## ✅ Checklist Before Submitting

- [x] I’ve tested the code locally and it works as expected
- [x] I’ve added screenshots if applicable
- [x] I’ve followed the code style and contribution guidelines

## 📸 Screenshots (if applicable)

Before:
<img width="1912" height="695" alt="Screenshot 2025-10-18 212609" src="https://github.com/user-attachments/assets/d4c0b1a1-63f3-4117-8a2c-20e241e5b959" />

After:

<img width="1904" height="898" alt="Screenshot 2025-10-19 154246" src="https://github.com/user-attachments/assets/8d9ce5b3-970f-41a8-9c52-47b7e5517769" />
